### PR TITLE
FAQ addition citation lists

### DIFF
--- a/help/faq/_posts/2017-10-24-faqs.md
+++ b/help/faq/_posts/2017-10-24-faqs.md
@@ -67,9 +67,9 @@ The easiest method is to link your Classic account to your the new ADS account a
 Nope! Existing Classic URLs will continue to work, even after Classic is retired.
 
 ##### Q: Where do I find the utility ***Get citation lists for selected articles*** and similar second order queries?
-In general, the function **Reviews** in the **Explore** menu will generate the same list of publications as selecting all records in the old ADS and clicking on the button *Get citation lists for selected articles*. The only difference is the fact that the new ADS does not offer the frequency: how many publications in the original set are cited by a publication in the result set. The results set in the old ADS is sorted by this frequency, so this is the only difference: a difference in sorting.
+In general, the function **Reviews** in the **Explore** menu will generate the same list of publications as selecting all records in the old ADS and clicking on the button *Get citation lists for selected articles*. The only difference is the fact that the new ADS does not show the frequency, but the results are sorted by the number of cites to the original set (when sorted by score).
 
-The new function **Useful** can be used in a similar way to generate the same results you would get the with button *Get reference lists for selected articles* in the old ADS.
+The new function **Useful** can be used in a similar way to generate the same results you would get the with button *Get reference lists for selected articles* in the old ADS. When "score" is selected for sorting, the records are sorted by the number of cites by the original set.
 
 The **Co-reads** function corresponds with *Get also-read lists for selected articles*.
 

--- a/help/faq/_posts/2017-10-24-faqs.md
+++ b/help/faq/_posts/2017-10-24-faqs.md
@@ -66,6 +66,13 @@ The easiest method is to link your Classic account to your the new ADS account a
 ##### Q: I have some links to Classic pages on my website - do I need to update all of these to the new ADS links?
 Nope! Existing Classic URLs will continue to work, even after Classic is retired.
 
+##### Q: Where do I find the utility ***Get citation lists for selected articles*** and similar second order queries?
+In general, the function **Reviews** in the **Explore** menu will generate the same list of publications as selecting all records in the old ADS and clicking on the button *Get citation lists for selected articles*. The only difference is the fact that the new ADS does not offer the frequency: how many publications in the original set are cited by a publication in the result set. The results set in the old ADS is sorted by this frequency, so this is the only difference: a difference in sorting.
+
+The new function **Useful** can be used in a similar way to generate the same results you would get the with button *Get reference lists for selected articles* in the old ADS.
+
+The **Co-reads** function corresponds with *Get also-read lists for selected articles*.
+
 ## ADS Libraries
 ##### Q: If I delete a record from the middle of a large private library, the page refreshes and deposits me back on the first page.
 To return to your previous position, use the jump-to box at the bottom of the list of records, between the previous and next page buttons.


### PR DESCRIPTION
Some Help text explaining where the Classic functionality `Get citation lists for selected articles` went