### PR TITLE
Apply ADS theme to API Doc

### DIFF
--- a/help/api/api-docs.html
+++ b/help/api/api-docs.html
@@ -17,8 +17,8 @@
     <style>
       .darkmode-toggle {
         background: #100f2c;
-        width: 4rem;
-        height: 4rem;
+        width: 3rem;
+        height: 3rem;
         position: fixed;
         border-radius: 50%;
         right: 32px;
@@ -32,9 +32,18 @@
         z-index: 100;
       }
 
+      rapi-doc::part(anchor) {
+        color: #4073dd;
+      }
+
       [data-theme='dark'] .darkmode-toggle {
         background: #fff;
       }
+
+      [data-theme='dark'] rapi-doc::part(anchor) {
+        color: #58a6ff;
+      }
+
     </style>
   </head>
   <body>
@@ -44,34 +53,46 @@
       render-style="read"
       schema-style="table"
       heading-text="adsAPI"
-      theme="light"
-      primary-color="#85A7EA"
+      regular-font="Helvetica Neue"
+      bg-color="#FFF";
+      primary-color="#4073DD"
+      text-color="#5D5D5D"
+      nav-bg-color="#EEE"
+      nav-text-color="#5D5D5D"
+      nav-accent-color="#4073DD"
       schema-description-expanded="true"
       show-header="false"
       fill-request-fields-with-example="false"
       font-size="largest"
     >
       <div
+        id="logo-container"
         slot="nav-logo"
-        style="display: flex; align-items: center; justify-content: center"
+        style="display: flex; align-items: center; justify-content: center; background-color: #EEE;"
       >
         <img
-          src="https://ui.adsabs.harvard.edu/help/common/images/transparent_logo.svg"
+          id="logo"
+          src="/help/img/bbb_assets/ads_partial_logo_dark_background.svg"
           style="width: 50px; margin-right: 10px"
         />
-        <span style="color: #fff; font-size: 175%"> <b>ads</b>API </span>
+        <span id="logo-text" style="color: #000; font-size: 175%"> <b>ads</b>API </span>
       </div>
     </rapi-doc>
-    <div id="darkSwitch" class="darkmode-toggle" title="Turn on dark mode">
-      🌓
-    </div>
+    <div id="darkSwitch" class="darkmode-toggle" title="Turn on dark mode">🌓</div>
   </body>
   <script>
     let darkSwitch;
 
     const turnOnDarkMode = (save) => {
       document.body.setAttribute('data-theme', 'dark');
-      document.querySelector('rapi-doc').setAttribute('theme', 'dark');
+      const rapidoc = document.querySelector('rapi-doc');
+      rapidoc.setAttribute('bg-color', '#21262d');
+      rapidoc.setAttribute('text-color', '#eee');
+      rapidoc.setAttribute('nav-bg-color', '#0d1117');
+      rapidoc.setAttribute('nav-text-color', '#eee');
+      document.querySelector('#logo').setAttribute('src', src="https://ui.adsabs.harvard.edu/help/common/images/transparent_logo.svg")
+      document.querySelector('#logo-container').style.backgroundColor = '#000'
+      document.querySelector('#logo-text').style.color = '#c9d1d9'
       darkSwitch.classList.add('darkModeOn');
       darkSwitch.setAttribute('title', 'Turn off dark mode');
       if (save) localStorage.setItem('darkSwitch', 'on');
@@ -79,7 +100,15 @@
 
     const turnOffDarkMode = (save) => {
       document.body.removeAttribute('data-theme');
-      document.querySelector('rapi-doc').setAttribute('theme', 'light');
+      const rapidoc = document.querySelector('rapi-doc');
+      rapidoc.setAttribute('bg-color', '#FFF');
+      rapidoc.setAttribute('text-color', '#5D5D5D');
+      rapidoc.setAttribute('nav-bg-color', '#EEE');
+      rapidoc.setAttribute('nav-text-color', '#5D5D5D');
+      rapidoc.setAttribute('nav-accent-color', '#4073DD');
+      document.querySelector('#logo').setAttribute('src', src="/help/img/bbb_assets/ads_partial_logo_dark_background.svg")
+      document.querySelector('#logo-container').style.backgroundColor = '#EEE'
+      document.querySelector('#logo-text').style.color = '#5D5D5D'
       darkSwitch.classList.remove('darkModeOn');
       darkSwitch.setAttribute('title', 'Turn on dark mode');
       if (save) localStorage.setItem('darkSwitch', 'off');

--- a/help/api/api-docs.html
+++ b/help/api/api-docs.html
@@ -14,6 +14,96 @@
       type="module"
       src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"
     ></script>
+    <script>
+      let darkSwitch;
+      let rapidoc;
+
+      const turnOnDarkMode = (save) => {
+        document.body.setAttribute('data-theme', 'dark');
+        rapidoc.setAttribute('theme', 'dark');
+        rapidoc.setAttribute('bg-color', '#21262d');
+        rapidoc.setAttribute('text-color', '#eee');
+        rapidoc.setAttribute('nav-bg-color', '#0d1117');
+        rapidoc.setAttribute('nav-text-color', '#eee');
+        rapidoc.setAttribute('nav-accent-color', '#58a6ff');
+        document.querySelector('#logo').setAttribute('src', src="https://ui.adsabs.harvard.edu/help/common/images/transparent_logo.svg")
+        document.querySelector('#logo-container').style.backgroundColor = '#000'
+        document.querySelector('#logo-text').style.color = '#c9d1d9'
+        darkSwitch.classList.add('darkModeOn');
+        darkSwitch.setAttribute('title', 'Turn off dark mode');
+        
+        // Change main content link color
+        const style = rapidoc.shadowRoot.querySelector('#custom-style');
+        style.innerHTML = '*,:after,:before{box-sizing:border-box}:host{--blue: #58a6ff}';
+
+        // save to local storage
+        if (save) localStorage.setItem('darkSwitch', 'on');
+      };
+
+      const turnOffDarkMode = (save) => {
+        document.body.removeAttribute('data-theme');
+        rapidoc.setAttribute('theme', 'light');
+        rapidoc.setAttribute('bg-color', '#FFF');
+        rapidoc.setAttribute('text-color', '#5D5D5D');
+        rapidoc.setAttribute('nav-bg-color', '#EEE');
+        rapidoc.setAttribute('nav-text-color', '#5D5D5D');
+        rapidoc.setAttribute('nav-accent-color', '#4073DD');
+        document.querySelector('#logo').setAttribute('src', src="/help/img/bbb_assets/ads_partial_logo_dark_background.svg")
+        document.querySelector('#logo-container').style.backgroundColor = '#EEE'
+        document.querySelector('#logo-text').style.color = '#5D5D5D'
+        darkSwitch.classList.remove('darkModeOn');
+        darkSwitch.setAttribute('title', 'Turn on dark mode');
+
+        // Change main content link color
+        const style = rapidoc.shadowRoot.querySelector('#custom-style');
+        style.innerHTML = '*,:after,:before{box-sizing:border-box}:host{--blue: #4073DD}';
+
+        // save to local storage
+        if (save) localStorage.setItem('darkSwitch', 'off');
+      };
+
+      const toggle = () => {
+        if (darkSwitch.classList.contains('darkModeOn')) {
+          turnOffDarkMode(true);
+        } else {
+          turnOnDarkMode(true);
+        }
+      };
+
+      const initTheme = () => {
+        // 1. check app setting
+        if (localStorage.getItem('darkSwitch') !== null) {
+          if (localStorage.getItem('darkSwitch') === 'on') {
+            turnOnDarkMode(false);
+          } else {
+            turnOffDarkMode(false);
+          }
+        } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          // 2. check system setting
+          turnOnDarkMode(false);
+        } else {
+          // 3. default to light
+          turnOffDarkMode(false);
+        }
+        darkSwitch.addEventListener('click', function () {
+          toggle();
+        });
+      };
+
+      // Setup theme and style when DOM is loaded
+      document.addEventListener("DOMContentLoaded", function(){
+        rapidoc = document.querySelector('rapi-doc');
+        darkSwitch = document.getElementById('darkSwitch');
+        const style = document.createElement('style');
+        style.setAttribute('id', 'custom-style');
+        style.innerHTML = '*,:after,:before{box-sizing:border-box}:host{--blue: #4073DD}';
+        rapidoc.shadowRoot.appendChild(style);
+        initTheme();
+
+        // hide body until theme is set to avoid flashing
+        document.body.style.visibility = 'visible';
+      });
+    </script>
     <style>
       .darkmode-toggle {
         background: #100f2c;
@@ -33,7 +123,7 @@
       }
 
       rapi-doc::part(anchor) {
-        color: #4073dd;
+        color: #4073DD;
       }
 
       [data-theme='dark'] .darkmode-toggle {
@@ -46,7 +136,7 @@
 
     </style>
   </head>
-  <body>
+  <body style="visibility: hidden;">
     <rapi-doc
       spec-url="https://raw.githubusercontent.com/adsabs/adsabs-dev-api/master/openapi/openapi_public.yaml"
       sort-endpoints-by="summary"
@@ -80,71 +170,4 @@
     </rapi-doc>
     <div id="darkSwitch" class="darkmode-toggle" title="Turn on dark mode">🌓</div>
   </body>
-  <script>
-    let darkSwitch;
-
-    const turnOnDarkMode = (save) => {
-      document.body.setAttribute('data-theme', 'dark');
-      const rapidoc = document.querySelector('rapi-doc');
-      rapidoc.setAttribute('bg-color', '#21262d');
-      rapidoc.setAttribute('text-color', '#eee');
-      rapidoc.setAttribute('nav-bg-color', '#0d1117');
-      rapidoc.setAttribute('nav-text-color', '#eee');
-      document.querySelector('#logo').setAttribute('src', src="https://ui.adsabs.harvard.edu/help/common/images/transparent_logo.svg")
-      document.querySelector('#logo-container').style.backgroundColor = '#000'
-      document.querySelector('#logo-text').style.color = '#c9d1d9'
-      darkSwitch.classList.add('darkModeOn');
-      darkSwitch.setAttribute('title', 'Turn off dark mode');
-      if (save) localStorage.setItem('darkSwitch', 'on');
-    };
-
-    const turnOffDarkMode = (save) => {
-      document.body.removeAttribute('data-theme');
-      const rapidoc = document.querySelector('rapi-doc');
-      rapidoc.setAttribute('bg-color', '#FFF');
-      rapidoc.setAttribute('text-color', '#5D5D5D');
-      rapidoc.setAttribute('nav-bg-color', '#EEE');
-      rapidoc.setAttribute('nav-text-color', '#5D5D5D');
-      rapidoc.setAttribute('nav-accent-color', '#4073DD');
-      document.querySelector('#logo').setAttribute('src', src="/help/img/bbb_assets/ads_partial_logo_dark_background.svg")
-      document.querySelector('#logo-container').style.backgroundColor = '#EEE'
-      document.querySelector('#logo-text').style.color = '#5D5D5D'
-      darkSwitch.classList.remove('darkModeOn');
-      darkSwitch.setAttribute('title', 'Turn on dark mode');
-      if (save) localStorage.setItem('darkSwitch', 'off');
-    };
-
-    const toggle = () => {
-      if (darkSwitch.classList.contains('darkModeOn')) {
-        turnOffDarkMode(true);
-      } else {
-        turnOnDarkMode(true);
-      }
-    };
-
-    const init = () => {
-      darkSwitch = document.getElementById('darkSwitch');
-      darkSwitch.classList.remove('hidden');
-
-      // 1. check app setting
-      if (localStorage.getItem('darkSwitch') !== null) {
-        if (localStorage.getItem('darkSwitch') === 'on') {
-          turnOnDarkMode(false);
-        } else {
-          turnOffDarkMode(false);
-        }
-      } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        // 2. check system setting
-        turnOnDarkMode(false);
-      } else {
-        // 3. default to light
-        turnOffDarkMode(false);
-      }
-      darkSwitch.addEventListener('click', function () {
-        toggle();
-      });
-    };
-
-    init();
-  </script>
 </html>

--- a/help/api/api-docs.html
+++ b/help/api/api-docs.html
@@ -1,28 +1,121 @@
-<!doctype html> <!-- Important: must specify -->
+<!DOCTYPE html>
+<!-- Important: must specify -->
 <html>
   <head>
-    <meta charset="utf-8"> <!-- Important: rapi-doc uses utf8 charecters -->
-    <title> ADS OpenAPI Docs </title>
-    <link rel="shortcut icon" type="image/jpg" href="https://ui.adsabs.harvard.edu/help/common/images/favicon-32x32.png"/>
-    <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+    <meta charset="utf-8" />
+    <!-- Important: rapi-doc uses utf8 charecters -->
+    <title>ADS OpenAPI Docs</title>
+    <link
+      rel="shortcut icon"
+      type="image/jpg"
+      href="https://ui.adsabs.harvard.edu/help/common/images/favicon-32x32.png"
+    />
+    <script
+      type="module"
+      src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"
+    ></script>
+    <style>
+      .darkmode-toggle {
+        background: #100f2c;
+        width: 4rem;
+        height: 4rem;
+        position: fixed;
+        border-radius: 50%;
+        right: 32px;
+        bottom: 32px;
+        left: unset;
+        cursor: pointer;
+        transition: all 0.5s ease;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        z-index: 100;
+      }
+
+      [data-theme='dark'] .darkmode-toggle {
+        background: #fff;
+      }
+    </style>
   </head>
   <body>
     <rapi-doc
-      spec-url = "https://raw.githubusercontent.com/adsabs/adsabs-dev-api/master/openapi/openapi_public.yaml"
-      sort-endpoints-by = "summary"
-      render-style = "read"
-      schema-style = "table"
-      heading-text = "adsAPI"
-      theme = "light"
-      primary-color = #85A7EA
-      schema-description-expanded = true
-      show-header = false
-      fill-request-fields-with-example = false
-      font-size = largest
+      spec-url="https://raw.githubusercontent.com/adsabs/adsabs-dev-api/master/openapi/openapi_public.yaml"
+      sort-endpoints-by="summary"
+      render-style="read"
+      schema-style="table"
+      heading-text="adsAPI"
+      theme="light"
+      primary-color="#85A7EA"
+      schema-description-expanded="true"
+      show-header="false"
+      fill-request-fields-with-example="false"
+      font-size="largest"
     >
-      <div slot="nav-logo" style="display: flex; align-items: center; justify-content: center;">
-        <img src="https://ui.adsabs.harvard.edu/help/common/images/transparent_logo.svg" style="width: 50px; margin-right: 10px"> <span style="color:#fff; font-size:175%"> <b>ads</b>API </span>
+      <div
+        slot="nav-logo"
+        style="display: flex; align-items: center; justify-content: center"
+      >
+        <img
+          src="https://ui.adsabs.harvard.edu/help/common/images/transparent_logo.svg"
+          style="width: 50px; margin-right: 10px"
+        />
+        <span style="color: #fff; font-size: 175%"> <b>ads</b>API </span>
       </div>
     </rapi-doc>
+    <div id="darkSwitch" class="darkmode-toggle" title="Turn on dark mode">
+      🌓
+    </div>
   </body>
+  <script>
+    let darkSwitch;
+
+    const turnOnDarkMode = (save) => {
+      document.body.setAttribute('data-theme', 'dark');
+      document.querySelector('rapi-doc').setAttribute('theme', 'dark');
+      darkSwitch.classList.add('darkModeOn');
+      darkSwitch.setAttribute('title', 'Turn off dark mode');
+      if (save) localStorage.setItem('darkSwitch', 'on');
+    };
+
+    const turnOffDarkMode = (save) => {
+      document.body.removeAttribute('data-theme');
+      document.querySelector('rapi-doc').setAttribute('theme', 'light');
+      darkSwitch.classList.remove('darkModeOn');
+      darkSwitch.setAttribute('title', 'Turn on dark mode');
+      if (save) localStorage.setItem('darkSwitch', 'off');
+    };
+
+    const toggle = () => {
+      if (darkSwitch.classList.contains('darkModeOn')) {
+        turnOffDarkMode(true);
+      } else {
+        turnOnDarkMode(true);
+      }
+    };
+
+    const init = () => {
+      darkSwitch = document.getElementById('darkSwitch');
+      darkSwitch.classList.remove('hidden');
+
+      // 1. check app setting
+      if (localStorage.getItem('darkSwitch') !== null) {
+        if (localStorage.getItem('darkSwitch') === 'on') {
+          turnOnDarkMode(false);
+        } else {
+          turnOffDarkMode(false);
+        }
+      } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        // 2. check system setting
+        turnOnDarkMode(false);
+      } else {
+        // 3. default to light
+        turnOffDarkMode(false);
+      }
+      darkSwitch.addEventListener('click', function () {
+        toggle();
+      });
+    };
+
+    init();
+  </script>
 </html>


### PR DESCRIPTION
Apply ADS theme to API Doc with dark and light modes.

![Screen Shot 2021-06-24 at 10 45 20 AM](https://user-images.githubusercontent.com/636361/123309045-48d76700-d4d9-11eb-8402-0306324e4d56.png)
![Screen Shot 2021-06-24 at 10 45 37 AM](https://user-images.githubusercontent.com/636361/123309082-512fa200-d4d9-11eb-93dc-e0c09860635b.png)
