### PR TITLE
Dark mode bug fix for when system setting is dark

### DIFF
--- a/help/common/js/dark-mode-switch.js
+++ b/help/common/js/dark-mode-switch.js
@@ -17,11 +17,12 @@
 
   const init = () => {
     // 1. check app setting
-    if (
-      localStorage.getItem('darkSwitch') !== null &&
-      localStorage.getItem('darkSwitch') === 'on'
-    ) {
-      turnOnDarkMode(false);
+    if (localStorage.getItem('darkSwitch') !== null) {
+      if (localStorage.getItem('darkSwitch') === 'on') {
+        turnOnDarkMode(false);
+      } else {
+        turnOffDarkMode(false);
+      }
     }
     // 2. check system setting
     else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {


### PR DESCRIPTION
Fixed the logic for checking and setting dark mode when page starts.
When user used dark system setting, the app setting was ignored. It should use app setting.