### PR TITLE
Fix blog image overlapping with content.

### DIFF
--- a/blog/index.md
+++ b/blog/index.md
@@ -15,7 +15,7 @@ layout: blog_page
 
         <div class="panel-body">
 
-            <div class="col-md-2">
+            <div class="col-lg-4">
                 {% if post.thumbnail %}
                     <img src="{{ site.baseurl }}/{{ post.thumbnail }}" style="max-width: 340px;height:auto"/>
                 {% else %}
@@ -23,9 +23,7 @@ layout: blog_page
                 {% endif %}
             </div>
 
-            <div class="col-md-2"></div>
-
-            <div class="col-md-8">
+            <div class="col-lg-8">
                 <h2>
                     <a href="{{ site.baseurl }}{{ post.url }}">{{post.title}}</a><br><small>{{ post.date | date_to_string }}</small>
                 </h2>


### PR DESCRIPTION
Use row display only when width is large, otherwise it's column display
---
<img width="1045" alt="Screen Shot 2023-02-16 at 4 20 47 PM" src="https://user-images.githubusercontent.com/636361/219489366-0dbf58a5-d985-4252-abc2-1429897ae557.png">
