### PR TITLE
fix:  add links to 2023 ADSUG Report 

### DIFF
--- a/about/adsug/_posts/2018-01-01-adsug.md
+++ b/about/adsug/_posts/2018-01-01-adsug.md
@@ -48,6 +48,7 @@ Current members of the ADSUG are:
 The last meeting of the ADSUG took place November 16--17, 2023, virtually and at the Center for Astrophysics \| Harvard & Smithsonian.
 
 - Nov. 2023 [Meeting agenda and presentations](../adsug/past_meetings/2023-11-16-202311-program.html)
+- Nov. 2023 [ADS Users Group Final Report](https://ads.harvard.edu/adsug/2023/ADSUGReport2023.pdf)
 
 A list of [prior Users Group meeting presentations, reports, and membership](../adsug/meetings.html) is available.
 

--- a/about/adsug/_posts/2018-01-01-meetings.md
+++ b/about/adsug/_posts/2018-01-01-meetings.md
@@ -11,7 +11,8 @@ Prior members and reports are listed below.
 ### November 16--17, 2023
 **Members**: J.J. Kavelaars (Chair), Matthew J. Graham (Vice Chair), Jason Barnes, Julianne Dalcanton, Vandana Desai, Silvia Meakins, Aimee Norton, Annalisa Pillepich, Licia Verde 
 
-**[Presentations](../adsug/past_meetings/2023-11-16-202311-program.html)**   
+**[Presentations](../adsug/past_meetings/2023-11-16-202311-program.html)**
+**[Report](https://ads.harvard.edu/adsug/2023/ADSUGReport2023.pdf)**
 
 ### November 9--10, 2022
 **Members**: Bryan Gaensler (Chair), Jason Barnes, Andy Casey, Julianne Dalcanton, Vandana Desai, J.J. Kavelaars, Aimee Norton, Jenny Novacescu, Annalisa Pillepich    

--- a/about/adsug/_posts/2018-01-01-meetings.md
+++ b/about/adsug/_posts/2018-01-01-meetings.md
@@ -11,7 +11,7 @@ Prior members and reports are listed below.
 ### November 16--17, 2023
 **Members**: J.J. Kavelaars (Chair), Matthew J. Graham (Vice Chair), Jason Barnes, Julianne Dalcanton, Vandana Desai, Silvia Meakins, Aimee Norton, Annalisa Pillepich, Licia Verde 
 
-**[Presentations](../adsug/past_meetings/2023-11-16-202311-program.html)**
+**[Presentations](../adsug/past_meetings/2023-11-16-202311-program.html)**  
 **[Report](https://ads.harvard.edu/adsug/2023/ADSUGReport2023.pdf)**
 
 ### November 9--10, 2022

--- a/about/adsug/past_meetings/2023-11-16-202311-program.md
+++ b/about/adsug/past_meetings/2023-11-16-202311-program.md
@@ -52,3 +52,5 @@ Virtual (Zoom links to be provided). All times EST.
 - Panel preliminary feedback and report to ADS
 
 2:00 pm: Adjourn
+
+### Final Report(https://ads.harvard.edu/adsug/2023/ADSUGReport2023.pdf)  

--- a/about/adsug/past_meetings/2023-11-16-202311-program.md
+++ b/about/adsug/past_meetings/2023-11-16-202311-program.md
@@ -53,4 +53,4 @@ Virtual (Zoom links to be provided). All times EST.
 
 2:00 pm: Adjourn
 
-### Final Report(https://ads.harvard.edu/adsug/2023/ADSUGReport2023.pdf)  
+### [Final Report](https://ads.harvard.edu/adsug/2023/ADSUGReport2023.pdf)  


### PR DESCRIPTION
Link to pdf version of ADSUG report 
https://ads.harvard.edu/adsug/2023/ADSUGReport2023.pdf
added to main ADSUG page, past ADSUG meeting page, 2023 ADSUG agenda