### PR TITLE
Fixed build issue w setup-ruby

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Ruby
-        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        uses: ruby/setup-ruby@v1 # latest major version, as per official recommendation 
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
Github updated their `ubuntu-latest` version which broke the pinned version of `setup-ruby` we had. Switched this to the latest major version, per the [official recommendation](https://github.com/ruby/setup-ruby/blob/f6e05710eced3c9c28e489afdc6fd8a3bc685325/README.md?plain=1#L238-L248).