### PR TITLE
Add Missing 2023 ADS UG Presentations

### DIFF
--- a/about/adsug/past_meetings/2023-11-16-202311-program.md
+++ b/about/adsug/past_meetings/2023-11-16-202311-program.md
@@ -25,9 +25,9 @@ Virtual (Zoom links to be provided). All times EST.
 
 12:05 pm Session 3
 - [System Development Overview](https://ads.harvard.edu/adsug/2023/System_Development_Overview.pdf) (10 mins)
-- [Back-office and DevOps Development updates](https://ads.harvard.edu/adsug/2023/BackOffice_DevOps-Update.pdf) (15 min)
+- [Back-office and DevOps Development updates](https://ads.harvard.edu/adsug/2023/Backoffice_DevOps-Updates.pdf) (15 min)
 - [SciX UI](https://ads.harvard.edu/adsug/2023/UserInterface.pdf) (15 min)
-- [Data Enrichment](https://ads.harvard.edu/adsug/2023/DataEnrichment.pdf) (15 min)
+- [Data Enrichment](https://ads.harvard.edu/adsug/2023/DataEnrichmentUpdates.pdf) (15 min)
 - [Artificial Intelligence and Machine Learning](https://ads.harvard.edu/adsug/2023/03.05SystemDevelopment-Future.pdf) (10 min)
 - Q&A (5 min)
 

--- a/about/adsug/past_meetings/2023-11-16-202311-program.md
+++ b/about/adsug/past_meetings/2023-11-16-202311-program.md
@@ -26,7 +26,7 @@ Virtual (Zoom links to be provided). All times EST.
 12:05 pm Session 3
 - [System Development Overview](https://ads.harvard.edu/adsug/2023/System_Development_Overview.pdf) (10 mins)
 - [Back-office and DevOps Development updates](https://ads.harvard.edu/adsug/2023/BackOffice_DevOps-Update.pdf) (15 min)
-- SciX UI (15 min)
+- [SciX UI](https://ads.harvard.edu/adsug/2023/UserInterface.pdf) (15 min)
 - [Data Enrichment](https://ads.harvard.edu/adsug/2023/DataEnrichment.pdf) (15 min)
 - [Artificial Intelligence and Machine Learning](https://ads.harvard.edu/adsug/2023/03.05SystemDevelopment-Future.pdf) (10 min)
 - Q&A (5 min)

--- a/about/adsug/past_meetings/2023-11-16-202311-program.md
+++ b/about/adsug/past_meetings/2023-11-16-202311-program.md
@@ -11,7 +11,7 @@ Virtual (Zoom links to be provided). All times EST.
 10:00 am: Session 1
 - [Introduction](https://ads.harvard.edu/adsug/2023/01.01ADSUG_2023_Introduction.pdf) (15 min)
 - Executive session (10 min)
-- Community Survey Results (15 min)
+- [Community Survey Results](https://ads.harvard.edu/adsug/2023/01.03-CommunityInput-ADSUG2023.pdf) (15 min)
 - [State of ADS](https://ads.harvard.edu/adsug/2023/State_of_ADS.pdf) (25 min)
 - Q&A (10 min)
 

--- a/about/adsug/past_meetings/2023-11-16-202311-program.md
+++ b/about/adsug/past_meetings/2023-11-16-202311-program.md
@@ -42,7 +42,7 @@ Virtual (Zoom links to be provided). All times EST.
 ### Friday, November 17, 2023
 10:00 am: Session 5
 - [User Support and Feedback](https://ads.harvard.edu/adsug/2023/05.01-UserSupport-ADSUG-2023.pdf) (10 min)
-- Community Engagement (10 min)
+- [Community Engagement](https://ads.harvard.edu/adsug/2023/05.02-CommunityEngagement-ADSUG2023.pdf) (10 min)
 - [From ADS to SciX](https://ads.harvard.edu/adsug/2023/05.03-TransitionAstronomers-ADSUG2023.pdf) (10 min)
 
 11:00 pm: Break

--- a/about/adsug/past_meetings/2023-11-16-202311-program.md
+++ b/about/adsug/past_meetings/2023-11-16-202311-program.md
@@ -41,9 +41,9 @@ Virtual (Zoom links to be provided). All times EST.
 
 ### Friday, November 17, 2023
 10:00 am: Session 5
-- User Support and Feedback (10 min)
+- [User Support and Feedback](https://ads.harvard.edu/adsug/2023/05.01-UserSupport-ADSUG-2023.pdf) (10 min)
 - Community Engagement (10 min)
-- From ADS to SciX (10 min)
+- [From ADS to SciX](https://ads.harvard.edu/adsug/2023/05.03-TransitionAstronomers-ADSUG2023.pdf) (10 min)
 
 11:00 pm: Break
 

--- a/about/adsug/past_meetings/2023-11-16-202311-program.md
+++ b/about/adsug/past_meetings/2023-11-16-202311-program.md
@@ -25,7 +25,7 @@ Virtual (Zoom links to be provided). All times EST.
 
 12:05 pm Session 3
 - [System Development Overview](https://ads.harvard.edu/adsug/2023/System_Development_Overview.pdf) (10 mins)
-- Back-office and DevOps Development updates (15 min)
+- [Back-office and DevOps Development updates](https://ads.harvard.edu/adsug/2023/BackOffice_DevOps-Update.pdf) (15 min)
 - SciX UI (15 min)
 - [Data Enrichment](https://ads.harvard.edu/adsug/2023/DataEnrichment.pdf) (15 min)
 - [Artificial Intelligence and Machine Learning](https://ads.harvard.edu/adsug/2023/03.05SystemDevelopment-Future.pdf) (10 min)

--- a/about/adsug/past_meetings/2023-11-16-202311-program.md
+++ b/about/adsug/past_meetings/2023-11-16-202311-program.md
@@ -9,7 +9,7 @@ Virtual (Zoom links to be provided). All times EST.
 
 ### Thursday, November 16, 2023
 10:00 am: Session 1
-- Introduction (15 min)
+- [Introduction](https://ads.harvard.edu/adsug/2023/01.01ADSUG_2023_Introduction.pdf) (15 min)
 - Executive session (10 min)
 - Community Survey Results (15 min)
 - [State of ADS](https://ads.harvard.edu/adsug/2023/State_of_ADS.pdf) (25 min)
@@ -27,14 +27,14 @@ Virtual (Zoom links to be provided). All times EST.
 - [System Development Overview](https://ads.harvard.edu/adsug/2023/System_Development_Overview.pdf) (10 mins)
 - Back-office and DevOps Development updates (15 min)
 - SciX UI (15 min)
-- Data Enrichment (15 min)
-- Artificial Intelligence and Machine Learning (10 min)
+- [Data Enrichment](https://ads.harvard.edu/adsug/2023/DataEnrichment.pdf) (15 min)
+- [Artificial Intelligence and Machine Learning](https://ads.harvard.edu/adsug/2023/03.05SystemDevelopment-Future.pdf) (10 min)
 - Q&A (5 min)
 
 1:15 pm: Break
 
 1:25 pm: Session 4
-- Content and Curation (30 min)
+- [Content and Curation](https://ads.harvard.edu/adsug/2023/04.01ContentandCuration.pdf) (30 min)
 - Q&A (5 min)
 
 2:00 pm: Adjourn


### PR DESCRIPTION
completing the 2023 presentation links before beginning changes for 2024 ADS Users Group meeting