### PR TITLE
new help page explaining defunct mirror sites

### DIFF
--- a/help/faq/_posts/2017-10-24-faqs.md
+++ b/help/faq/_posts/2017-10-24-faqs.md
@@ -96,3 +96,6 @@ We support all current versions (within the last 5 years) of Chrome, Firefox, Sa
 
 ##### Q: How should I acknowledge ADS?
 If you wish to acknowledge us in a publication, kindly use a phrase such as the following: “This research has made use of the Astrophysics Data System, funded by NASA under Cooperative Agreement 80NSSC21M00561.” If you are using the ADS as a tool for bibliometric studies, please make sure you have an in-depth understanding of the system, its features and limitations, by reading and citing as appropriate the relevant published literature about ADS ([refereed](https://ui.adsabs.harvard.edu/#/public-libraries/aI9-ox_2RNeZK-gm-4DpVQ), [non-refereed](https://ui.adsabs.harvard.edu/#/public-libraries/iETdWs2pSGajhFBI30X3UQ)).
+
+##### Q: Do you have any mirror sites? 
+No, once we moved our site to the cloud in 2018, we no longer host mirror sites. See our [mirror policy page](https://ui.adsabs.harvard.edu/help/policies/mirrors) for more information.

--- a/help/policies/_posts/2024-02-12-mirrors.md
+++ b/help/policies/_posts/2024-02-12-mirrors.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: "ADS Mirror Links"
+order: 5
+category: policies
+---
+# ADS Mirror Links Update
+
+Previously, ADS had mirror sites hosted at servers across the world that were listed at [http://adsabs.harvard.edu/mirrors.html](http://adsabs.harvard.edu/mirrors.html). However, these mirror sites have been defunct since mid-2018 when we upgraded our infrastructure from being hosted at local servers to cloud based. This move to the cloud was made to improve the speed and reliability of ADS as our content base was growing. For more information, please see this blog post titled [Classic ADS and the New ADS](https://ui.adsabs.harvard.edu/blog/technical). 

--- a/help/policies/_posts/2024-02-12-mirrors.md
+++ b/help/policies/_posts/2024-02-12-mirrors.md
@@ -1,8 +1,10 @@
 ---
 layout: post
-title: "ADS Mirror Links Update"
-order: 5
+title: "ADS Mirror Links Policy"
+order: 6
 category: policies
 ---
 
-Previously, ADS had mirror sites hosted at servers across the world that were listed at [http://adsabs.harvard.edu/mirrors.html](http://adsabs.harvard.edu/mirrors.html). However, these mirror sites have been defunct since mid-2018 when we upgraded our infrastructure from being hosted at local servers to cloud based. This move to the cloud was made to improve the speed and reliability of ADS as our content base was growing. For more information, please see this blog post outlining the differences between the [Classic ADS and the New ADS](https://ui.adsabs.harvard.edu/blog/technical). 
+# Mirror Links Policy
+
+ADS does not currently host mirror sites, unlike ADS Classic. We removed our mirror sites in 2018 when we upgraded our site infrastructure from being hosted on local servers to cloud based. This move to the cloud was made to improve the speed and reliability of ADS as our content base was growing. For more information, please see this blog post outlining the differences between the [Classic ADS and the New ADS](https://ui.adsabs.harvard.edu/blog/technical). 

--- a/help/policies/_posts/2024-02-12-mirrors.md
+++ b/help/policies/_posts/2024-02-12-mirrors.md
@@ -1,9 +1,8 @@
 ---
 layout: post
-title: "ADS Mirror Links"
+title: "ADS Mirror Links Update"
 order: 5
 category: policies
 ---
-# ADS Mirror Links Update
 
-Previously, ADS had mirror sites hosted at servers across the world that were listed at [http://adsabs.harvard.edu/mirrors.html](http://adsabs.harvard.edu/mirrors.html). However, these mirror sites have been defunct since mid-2018 when we upgraded our infrastructure from being hosted at local servers to cloud based. This move to the cloud was made to improve the speed and reliability of ADS as our content base was growing. For more information, please see this blog post titled [Classic ADS and the New ADS](https://ui.adsabs.harvard.edu/blog/technical). 
+Previously, ADS had mirror sites hosted at servers across the world that were listed at [http://adsabs.harvard.edu/mirrors.html](http://adsabs.harvard.edu/mirrors.html). However, these mirror sites have been defunct since mid-2018 when we upgraded our infrastructure from being hosted at local servers to cloud based. This move to the cloud was made to improve the speed and reliability of ADS as our content base was growing. For more information, please see this blog post outlining the differences between the [Classic ADS and the New ADS](https://ui.adsabs.harvard.edu/blog/technical). 


### PR DESCRIPTION
Not sure where to put this page. I added it to policy, but let me know if a different place is better. 