### PR TITLE
Update 2019-01-01-conf_proc.md

### DIFF
--- a/help/data_faq/_posts/2019-01-01-conf_proc.md
+++ b/help/data_faq/_posts/2019-01-01-conf_proc.md
@@ -51,7 +51,7 @@ Provide written permission from the copyright holder allowing the ADS to publish
 
 Feel free to modify as you see fit, especially item three, then send a copy of a signed copy of the permission letter to:
 
-        Donna Thompson
+        Alberto Accomazzi
         Astrophysics Data System
         Harvard-Smithsonian Center for Astrophysics
         60 Garden Street, M.S. 83


### PR DESCRIPTION
Replaced Donna Thompson, who is no longer with CfA, with Alberto Accomazzi as the contact for the permission letter