### PR TITLE
fix(feed): escape author and title fields in Atom feed template

### DIFF
--- a/help/common/feed.xml
+++ b/help/common/feed.xml
@@ -6,7 +6,7 @@ layout: null
  
   <title>NASA/SAO Astrophysics Data System</title>
   <link href="https://ui.adsabs.harvard.edu/"/>
-  <link type="application/atom+xml" rel="self" href="http://adsabs.github.io/atom.xml"/>
+  <link type="application/atom+xml" rel="self" href="https://adsabs.github.io/atom.xml"/>
   <updated>{{ site.time | date_to_xmlschema }}</updated>
   <id>https://ui.adsabs.harvard.edu/</id>
   <author>
@@ -15,20 +15,24 @@ layout: null
   </author>
   <rights>Copyright © 2015, NASA/SAO Astrophysics Data System</rights>
 
-  {% for post in site.posts limit:10 %}
-      {% if post.category contains 'blog' %}
+  {% assign blog_posts = site.posts | where: "category", "blog" %}
+  {% for post in blog_posts limit: 10 %}
       <entry>
-        <id>http://adsabs.github.io{{ post.id }}</id>
-        <link type="text/html" rel="alternate" href="https://adsabs.github.io{{ post.url }}"/>
-        <title>{{ post.title }}</title>
+        <id>http://adsabs.github.io{{ post.id | xml_escape }}</id>
+        <link type="text/html" rel="alternate" href="https://adsabs.github.io{{ post.url | xml_escape }}"/>
+        <title>{{ post.title | xml_escape }}</title>
         <published>{{ post.date | date_to_xmlschema }}</published>
         <updated>{{ post.date | date_to_xmlschema }}</updated>
         <author>
-          <name>{{ post.author }}</name>
+          <name>{{ post.author | xml_escape }}</name>
         </author>
+        {% if post.description %}
+        <summary>{{ post.description | xml_escape }}</summary>
+        {% else %}
+        <summary>{{ post.content | strip_html | replace: '&amp;', '&' | replace: '&lt;', '<' | replace: '&gt;', '>' | replace: '&quot;', '"' | replace: '&#39;', "'" | truncatewords: 50 | xml_escape }}</summary>
+        {% endif %}
         <content type="html">{{ post.content | xml_escape }}</content>
       </entry>
-      {% endif %}
   {% endfor %}
  
 </feed>


### PR DESCRIPTION
Three bugs in the Atom feed template. post.author and post.title were missing xml_escape, causing a parse error on any post with '&' in those fields (at least five affected). The limit:10 ran before the category filter, filling the feed window with same-date posts from both blog/ and scixblog/ collections. The 'contains blog' check also matched scixblog as a substring, doubling every entry.

- Applied xml_escape to post.title and post.author
- Pre-filter with where: "category", "blog" so limit:10 applies to the right set
- Dropped the now-redundant in-loop category check
- Added `<summary>` to each entry — uses post.description from front matter if present, falls back to the first 50 words of rendered text